### PR TITLE
Fix YUV encoding error and improve accuracy

### DIFF
--- a/app/src/main/cpp/native-lib.cpp
+++ b/app/src/main/cpp/native-lib.cpp
@@ -97,8 +97,8 @@ Java_facebook_f8demo_ClassifyCamera_classificationFromCaffe2(
 
     for (auto i = 0; i < iter_h; ++i) {
         jbyte* Y_row = &Y_data[(h_offset + i) * w];
-        jbyte* U_row = &U_data[(h_offset + i) / 4 * rowStride];
-        jbyte* V_row = &V_data[(h_offset + i) / 4 * rowStride];
+        jbyte* U_row = &U_data[(h_offset + i) / 2 * rowStride];
+        jbyte* V_row = &V_data[(h_offset + i) / 2 * rowStride];
         for (auto j = 0; j < iter_w; ++j) {
             // Tested on Pixel and S7.
             char y = Y_row[w_offset + j];


### PR DESCRIPTION
The YUV420 [format](https://msdn.microsoft.com/en-us/library/windows/desktop/dd206750(v=vs.85).aspx) in Android is NV12 rather than YV12.  The U and V channels share the same plane, so the memory location for U and V channels should be divided by 2 rather than 4. 